### PR TITLE
Rolling back css-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "babel-loader": "^6.4.1",
     "babel-preset-es2015": "^6.24.0",
     "cross-env": "^4.0.0",
-    "css-loader": "^0.27.3",
+    "css-loader": "^0.26.2",
     "file-loader": "^0.11.1",
     "rimraf": "^2.6.1",
     "uglify-js": "git://github.com/mishoo/UglifyJS2.git#harmony",

--- a/src/components/ShareButtonsComponent.vue
+++ b/src/components/ShareButtonsComponent.vue
@@ -23,7 +23,6 @@ export default {
 }
 </script>
 
-
 <style scoped>
   #share-buttons a {
     display: inline-block;

--- a/src/components/ShareButtonsComponent.vue
+++ b/src/components/ShareButtonsComponent.vue
@@ -23,6 +23,7 @@ export default {
 }
 </script>
 
+
 <style scoped>
   #share-buttons a {
     display: inline-block;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: '[name].js'
+    filename: 'my-vue-component.js'
   },
   resolve: {
     extensions: ['.js', '.vue'],
@@ -38,15 +38,7 @@ if (process.env.NODE_ENV === 'production') {
         NODE_ENV: '"production"'
       }
     }),
-    new webpack.optimize.CommonsChunkPlugin({
-      name: 'vendor',
-      minChunks: function (module) {
-        // this assumes your vendor imports exist in the node_modules directory
-        return module.context && module.context.indexOf('node_modules') !== -1;
-      }
-    }),
     new webpack.optimize.UglifyJsPlugin({
-      sourceMap: true,
       compress: {
         warnings: false
       }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,9 +2,7 @@ const path = require('path')
 const webpack = require('webpack')
 
 module.exports = {
-  entry: {
-    main: './src/main.js'
-  },
+  entry: './src/main.js',
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'my-vue-component.js'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,10 +2,12 @@ const path = require('path')
 const webpack = require('webpack')
 
 module.exports = {
-  entry: './src/main.js',
+  entry: {
+    main: './src/main.js'
+  },
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'my-vue-component.js'
+    filename: '[name].js'
   },
   resolve: {
     extensions: ['.js', '.vue'],
@@ -34,6 +36,13 @@ if (process.env.NODE_ENV === 'production') {
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: '"production"'
+      }
+    }),
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'vendor',
+      minChunks: function (module) {
+        // this assumes your vendor imports exist in the node_modules directory
+        return module.context && module.context.indexOf('node_modules') !== -1;
       }
     }),
     new webpack.optimize.UglifyJsPlugin({


### PR DESCRIPTION
There's a bug in css-loader that is adding about 20kbs to the webpack build. It's adding the buffer module unnecessary.